### PR TITLE
Set customer name/email from Mercado Pago

### DIFF
--- a/server/__tests__/mercadopagoPayments.test.js
+++ b/server/__tests__/mercadopagoPayments.test.js
@@ -41,5 +41,7 @@ describe('Mercado Pago payments route', () => {
     const sales = await prisma.sale.findMany({ where: { paymentId: '1' } });
     expect(sales.length).toBe(1);
     expect(sales[0].paymentMethod).toBe('pix');
+    expect(sales[0].customerName).toBe('John');
+    expect(sales[0].customerEmail).toBe('john@example.com');
   });
 });

--- a/server/src/routes/mercadopagoPayments.js
+++ b/server/src/routes/mercadopagoPayments.js
@@ -56,8 +56,12 @@ router.get('/', async (req, res) => {
             status
           }
         });
-      } else if (existing.status !== status) {
-        await prisma.sale.update({ where: { id: existing.id }, data: { status } });
+      } else {
+        const updateData = { status };
+        // Sempre atualiza o nome e email do cliente para refletir o pagamento mais recente
+        updateData.customerName = cliente;
+        updateData.customerEmail = pay.payer?.email || '';
+        await prisma.sale.update({ where: { id: existing.id }, data: updateData });
       }
     }
 


### PR DESCRIPTION
## Summary
- sync payments with latest customer name and email
- verify stored customer info in Mercado Pago payments tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff8a08afc832e973d04950460125b