### PR TITLE
Refactor Mercado Pago config

### DIFF
--- a/server/src/routes/mercadopago.js
+++ b/server/src/routes/mercadopago.js
@@ -7,26 +7,13 @@ const prisma = new PrismaClient();
 const dotenv = require('dotenv');
 dotenv.config();
 
-// Função para obter as configurações do Mercado Pago
-async function getMercadoPagoConfig() {
-  const config = await prisma.config.findFirst();
-  
-  if (!config || !config.mercadoPagoAccessToken) {
-    throw new Error('Configurações do Mercado Pago não encontradas');
-  }
-  
-  return {
-    accessToken: config.mercadoPagoAccessToken,
-    publicKey: config.mercadoPagoPublicKey,
-    webhookUrl: config.mercadoPagoWebhookUrl,
-    notificationUrl: config.mercadoPagoNotificationUrl
-  };
-}
+const { getMercadoPagoConfig } = require('../utils/mercadopagoConfig');
+
 
 // Inicializar o SDK do Mercado Pago com o token de acesso
 async function initMercadoPago() {
   try {
-    const { accessToken } = await getMercadoPagoConfig();
+    const { accessToken } = await getMercadoPagoConfig(prisma);
     return new MercadoPagoConfig({ accessToken });
   } catch (error) {
     console.error('Erro ao inicializar Mercado Pago:', error);
@@ -44,7 +31,7 @@ router.post('/create-preference', async (req, res) => {
     }
 
     // Obter configurações do Mercado Pago
-    const { accessToken, notificationUrl } = await getMercadoPagoConfig();
+    const { accessToken, notificationUrl } = await getMercadoPagoConfig(prisma);
 
     // Inicializar SDK com novo formato
     const mercadoPagoClient = new MercadoPagoConfig({ accessToken });
@@ -139,7 +126,7 @@ router.post('/create-cart-preference', async (req, res) => {
     }
 
     // Obter configurações do Mercado Pago
-    const { accessToken } = await getMercadoPagoConfig();
+    const { accessToken } = await getMercadoPagoConfig(prisma);
 
     // Inicializar SDK com novo formato
     const mercadoPagoClient = new MercadoPagoConfig({ accessToken });

--- a/server/src/routes/mercadopagoPayments.js
+++ b/server/src/routes/mercadopagoPayments.js
@@ -4,19 +4,12 @@ const { PrismaClient } = require('@prisma/client');
 const router = express.Router();
 const prisma = new PrismaClient();
 
-// Obtém as credenciais do Mercado Pago salvas na tabela Config
-async function getMercadoPagoConfig() {
-  const config = await prisma.config.findFirst();
-  if (!config || !config.mercadoPagoAccessToken) {
-    throw new Error('Configurações do Mercado Pago não encontradas');
-  }
-  return { accessToken: config.mercadoPagoAccessToken };
-}
+const { getMercadoPagoConfig } = require('../utils/mercadopagoConfig');
 
 // Sincroniza pagamentos do Mercado Pago armazenando na tabela Sale
 router.get('/', async (req, res) => {
   try {
-    const { accessToken } = await getMercadoPagoConfig();
+    const { accessToken } = await getMercadoPagoConfig(prisma);
     const response = await fetch('https://api.mercadopago.com/v1/payments/search', {
       headers: { Authorization: `Bearer ${accessToken}` }
     });

--- a/server/src/utils/mercadopagoConfig.js
+++ b/server/src/utils/mercadopagoConfig.js
@@ -1,0 +1,16 @@
+async function getMercadoPagoConfig(prisma) {
+  const config = await prisma.config.findFirst();
+
+  if (!config || !config.mercadoPagoAccessToken) {
+    throw new Error('Configurações do Mercado Pago não encontradas');
+  }
+
+  return {
+    accessToken: config.mercadoPagoAccessToken,
+    publicKey: config.mercadoPagoPublicKey,
+    webhookUrl: config.mercadoPagoWebhookUrl,
+    notificationUrl: config.mercadoPagoNotificationUrl
+  };
+}
+
+module.exports = { getMercadoPagoConfig };


### PR DESCRIPTION
## Summary
- centralize Mercado Pago configuration helper
- reuse the helper in Mercado Pago routes

## Testing
- `npm test --prefix server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff8a56694832eb6038d37bacf1a08