### PR TITLE
Enable credit card installments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ GET /api/mercadopago/payments
 
 Essa chamada busca os pagamentos usando o token configurado e registra cada um na tabela `Sale` com o método informado pelo Mercado Pago.
 
+As preferências de pagamento geradas pelas rotas `/api/mercadopago/create-preference` e `/api/mercadopago/create-cart-preference` agora permitem parcelamento em até 12 vezes no cartão de crédito.
+
 Para rodar os testes utilize:
 
 ```

--- a/server/src/routes/mercadopago.js
+++ b/server/src/routes/mercadopago.js
@@ -88,6 +88,9 @@ router.post('/create-preference', async (req, res) => {
         failure: `https://www.mariliaeiago.com.br/presentes/confirmacao?order_id=${order.id}`,
         pending: `https://www.mariliaeiago.com.br/presentes/confirmacao?order_id=${order.id}`,
       },
+      payment_methods: {
+        installments: 12 // Permitir parcelamento em até 12x
+      },
       auto_return: 'approved',
       statement_descriptor: siteTitle
     };
@@ -203,6 +206,9 @@ router.post('/create-cart-preference', async (req, res) => {
         success: `https://www.mariliaeiago.com.br/presentes/confirmacao?cart_id=${cart.id}`,
         failure: `https://www.mariliaeiago.com.br/presentes/confirmacao?cart_id=${cart.id}`,
         pending: `https://www.mariliaeiago.com.br/presentes/confirmacao?cart_id=${cart.id}`,
+      },
+      payment_methods: {
+        installments: 12 // Permitir parcelamento em até 12x
       },
       auto_return: 'approved',
       statement_descriptor: siteTitle


### PR DESCRIPTION
## Summary
- allow payment preferences to use credit card installments
- note the installment support in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c26dffb0832e865f5fcf66e1d920